### PR TITLE
fix for the error - wrong number of arguments for expire command

### DIFF
--- a/asyncio_redis_rate_limit/compat.py
+++ b/asyncio_redis_rate_limit/compat.py
@@ -47,7 +47,7 @@ def pipeline_expire(
 ) -> AnyPipeline:
     """Compatibility mode for `.expire(..., nx=True)` command."""
     if isinstance(pipeline, _AsyncPipeline):
-        return pipeline.expire(cache_key, seconds, nx=True)  # type: ignore
+        return pipeline.expire(cache_key, seconds)  # type: ignore
     # `aioredis` somehow does not have this boolean argument in `.expire`,
     # so, we use `EXPIRE` directly with `NX` flag.
     return pipeline.execute_command(  # type: ignore


### PR DESCRIPTION
I suspect this issue was due to the underlying library's api signature change

this was tested on 

python v3.10,
redis-stack-server c6.2.7
redis-py v4.3.5