### PR TITLE
fix: remove per-instance asyncio.Lock that never guards anything

### DIFF
--- a/asyncio_redis_rate_limit/__init__.py
+++ b/asyncio_redis_rate_limit/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 from collections.abc import Awaitable, Callable
 from functools import wraps
@@ -47,7 +46,6 @@ class RateLimiter:
     __slots__ = (
         '_backend',
         '_cache_prefix',
-        '_lock',
         '_rate_spec',
         '_unique_key',
     )
@@ -65,7 +63,6 @@ class RateLimiter:
         self._rate_spec = rate_spec
         self._backend = backend
         self._cache_prefix = cache_prefix
-        self._lock = asyncio.Lock()
 
     async def __aenter__(self: _RateLimiterT) -> _RateLimiterT:
         """
@@ -95,11 +92,15 @@ class RateLimiter:
         )
         pipeline = self._backend.pipeline()
 
-        async with self._lock:
-            current_rate = await self._run_pipeline(cache_key, pipeline)
-            # This looks like a coverage error on 3.10:
-            if current_rate > self._rate_spec.requests:  # pragma: no cover
-                raise RateLimitError('Rate limit is hit', current_rate)
+        # `pipeline()` defaults to `transaction=True`, so redis itself
+        # atomically serializes the incr+expire below: a per-instance
+        # `asyncio.Lock` here would not add any safety (a fresh `RateLimiter`,
+        # and thus a fresh lock, is created on every call, so it can never be
+        # contended) while still costing an allocation on every call.
+        current_rate = await self._run_pipeline(cache_key, pipeline)
+        # This looks like a coverage error on 3.10:
+        if current_rate > self._rate_spec.requests:  # pragma: no cover
+            raise RateLimitError('Rate limit is hit', current_rate)
 
     async def _run_pipeline(
         self,

--- a/tests/test_concurrent_within_loop.py
+++ b/tests/test_concurrent_within_loop.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+from typing import Final
+
+import pytest
+
+from asyncio_redis_rate_limit import RateLimitError, RateSpec, rate_limit
+from asyncio_redis_rate_limit.compat import (  # type: ignore
+    HAS_REDIS,
+    _AsyncRedis,  # ruff:ignore[import-private-name]
+)
+
+if not HAS_REDIS:
+    pytest.skip('`redis` package is not installed', allow_module_level=True)
+
+_redis: Final = _AsyncRedis.from_url(
+    'redis://{}:6379'.format(os.environ.get('REDIS_HOST', 'localhost')),
+)
+_LIMIT: Final = 10
+_TOTAL: Final = 100
+
+
+@rate_limit(
+    rate_spec=RateSpec(requests=_LIMIT, seconds=60),
+    backend=_redis,
+    cache_prefix='concurrent-within-loop',
+)
+async def _limited(index: int) -> int:
+    return index
+
+
+async def test_concurrent_calls_enforce_limit() -> None:
+    """Regression test.
+
+    A shared-nothing per-call lock cannot serialize concurrent calls from
+    the *same* event loop either (each call builds its own fresh
+    `RateLimiter`/lock), so correctness must come from the redis pipeline's
+    own atomicity, not the lock. Admitted/denied counts must match the
+    configured limit regardless.
+    """
+    gather_outcomes = await asyncio.gather(
+        *(_limited(attempt) for attempt in range(_TOTAL)),
+        return_exceptions=True,
+    )
+
+    admitted = [
+        outcome
+        for outcome in gather_outcomes
+        if not isinstance(outcome, BaseException)
+    ]
+    denied = [
+        outcome
+        for outcome in gather_outcomes
+        if isinstance(outcome, RateLimitError)
+    ]
+    unexpected_errors = [
+        outcome
+        for outcome in gather_outcomes
+        if isinstance(outcome, BaseException)
+        and not isinstance(outcome, RateLimitError)
+    ]
+
+    assert not unexpected_errors
+    assert len(admitted) == _LIMIT
+    assert len(denied) == _TOTAL - _LIMIT


### PR DESCRIPTION
`RateLimiter.__aenter__` creates a brand new `RateLimiter` (and
therefore a brand new `asyncio.Lock`) on every call in the
`rate_limit` decorator, so the lock is never shared between
concurrent calls to the same rate-limited function and can never
actually be contended -- it always acquires immediately. The
pipeline built with `.pipeline()` already defaults to
`transaction=True`, so the incr+expire is atomic on the redis side
regardless.

### Test plan
- New test: 100 concurrent asyncio calls within a single event loop against a real redis instance, limit of 10. 14 passing before, 15 passing after; admitted/denied counts (10/90) identical whether run against this change or against the prior lock-holding code, confirming the lock was never load-bearing.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.